### PR TITLE
fix(CSN-739): rate limiting the request to get running miners from wandb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ paramiko==3.4.1
 blake3
 ipwhois==1.3.0
 torch==2.5.1
+async-lru==2.0.4


### PR DESCRIPTION
expensive wandb query seems to bring down the register-api
add 2 seconds cache to few of the expensive endpoints that shares miner specs data from wandb.
it actually improves the response time as data is from cache, however, this needs to be carefully used.
